### PR TITLE
Fixed broken link to PowerShell.org on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@ title: About
 
 I'm Thomas Malkewitz (@dotps1), a System Engineer with a passion for automation and scripting, especially with PowerShell.
 I'm also the Founder/President of the <a href="https://grposh.github.io">Grand Rapids PowerShell User Group</a>.
-I am heavily involved with <a href="PowerShell.org">PowerShell.org</a>, and I am an active member of the global PowerShell community.
+I am heavily involved with <a href="https://PowerShell.org">PowerShell.org</a>, and I am an active member of the global PowerShell community.
 I enjoy making PowerShell _Wrappers_ for hard to use or dated DOS command line tools, and other applications that do not have PowerShell cmdlets.
 I also enjoy making helper functions that are missing from the core functionality of PowerShell for everyday use.
 My other hobbies consist of biking, both on the road and single trail.


### PR DESCRIPTION
Relative URL of `PowerShell.org` was incorrectly navigating to `https://dotps1.github.io/PowerShell.org` instead of the expected `https://PowerShell.org`.